### PR TITLE
Fix formspree.io contact form redirection with ReCaptcha

### DIFF
--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -2,6 +2,7 @@
 <h2>{{ .Site.Params.contact.title }}</h2>
 {{ if not .Site.Params.contact.postURL }}
   <form action="https://formspree.io/{{ with .Site.Params.contact.email }}{{.}}{{ end }}" method="post" name="sentMessage" id="contactForm" novalidate>
+    <input type="text" name="_gotcha" style="display:none" />
 {{ else }}
   <form  action="{{ .Site.Params.contact.postURL }}" method="POST" name="sentMessage" id="contactForm" novalidate>
 {{ end }}

--- a/static/assets/js/contact.js
+++ b/static/assets/js/contact.js
@@ -14,15 +14,15 @@ $('form[id=contactForm]').change(function() {
 
 // Async contact form
 $('form[id=contactForm]').submit(function(){
-  $.post($(this).attr('action'), $(this).serialize(), function(res){
-    $('form[id=contactForm] #success').hide();
-    $('form[id=contactForm] #error').hide();
-    if (res.code == "200")
+  $('form[id=contactForm] #success').hide();
+  $('form[id=contactForm] #error').hide();
+
+  // AJAX POST, with contact form data serialized, which expects a JSON response
+  // Datatype must be set to 'json' to use formspree.io
+  $.post($(this).attr('action'), $(this).serialize(), function(){
       $('form[id=contactForm] #success').show();
-    }).fail(function(){
-    $('form[id=contactForm] #success').hide();
-    $('form[id=contactForm] #error').hide();
-    $('form[id=contactForm] #error').show();
+    }, 'json').fail(function(){
+      $('form[id=contactForm] #error').show();
   });
   return false;
 });


### PR DESCRIPTION
Force the response dataType to 'json' to avoid running into the same-origin policy issue.