### PR TITLE
Use relative URLs for assets and images

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -23,7 +23,7 @@
         <!-- Main -->
           <section id="main">
             <header>
-              <span class="avatar"><img src="/images/avatars/{{ .Site.Params.personal.avatar }}" alt="avatar" height="130" width="130" ></span>
+              <span class="avatar"><img src="{{ .Site.Params.personal.avatar | printf "/images/avatars/%s" | relURL  }}" alt="avatar" height="130" width="130" ></span>
               <h1 class="name">
                 {{ with .Site.Params.personal.name }}
                   {{ . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,23 +16,23 @@
   {{ end }}
   <link rel="apple-touch-icon-precomposed" href="{{ .Site.Params.appleicon | printf "/images/icons/%s" | relURL  }}" />
 
-	<link rel="stylesheet" href="{{ "/assets/css/main.css" | relURL }}" />
+  <link rel="stylesheet" href="{{ "/assets/css/main.css" | relURL }}" />
 
   {{ if not .Site.Params.custom_background }}
-		<link rel="stylesheet" href="{{ "/assets/css/page.css" | relURL }}" />
+    <link rel="stylesheet" href="{{ "/assets/css/page.css" | relURL }}" />
   {{ end }}
 
   {{ if not .Site.Params.custom_icons }}
-		<link rel="stylesheet" href="{{ "/assets/css/font-awesome.min.css" | relURL }}" />
+    <link rel="stylesheet" href="{{ "/assets/css/font-awesome.min.css" | relURL }}" />
   {{ end }}
 
   {{ range .Site.Params.custom_css }}
     <link rel="stylesheet" href="{{ . | absURL }}">
   {{ end }}
 
-	<!--[if lte IE 8]><script src="{{ "/assets/js/html5shiv.js" | relURL }}"></script><![endif]-->
-	<!--[if lte IE 8]><link rel="stylesheet" href="{{ "/assets/css/ie8.css" | relURL }}" /><![endif]-->
-	<!--[if lte IE 9]><link rel="stylesheet" href="{{ "/assets/css/ie9.css" | relURL }}" /><![endif]-->
+  <!--[if lte IE 8]><script src="{{ "/assets/js/html5shiv.js" | relURL }}"></script><![endif]-->
+  <!--[if lte IE 8]><link rel="stylesheet" href="{{ "/assets/css/ie8.css" | relURL }}" /><![endif]-->
+  <!--[if lte IE 9]><link rel="stylesheet" href="{{ "/assets/css/ie9.css" | relURL }}" /><![endif]-->
 
-	<noscript><link rel="stylesheet" href="{{ "/assets/css/noscript.css" | relURL }}" /></noscript>
+  <noscript><link rel="stylesheet" href="{{ "/assets/css/noscript.css" | relURL }}" /></noscript>
 </head>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,33 +6,33 @@
   <meta name="author" content="{{ with .Site.Params.name }}{{ . }}{{ end }}">
   {{ .Hugo.Generator }}
   {{ if .Site.Params.favicon_ico }}
-    <link rel="icon" href="/images/icons/{{ .Site.Params.favicon_ico  }}" type="image/x-icon" {{ if .Site.Params.favicon_ico_sizes }}sizes="{{ .Site.Params.favicon_ico_sizes  }}"{{ end }} />
+    <link rel="icon" href="{{ .Site.Params.favicon_ico | printf "/images/icons/%s" | relURL  }}" type="image/x-icon" {{ if .Site.Params.favicon_ico_sizes }}sizes="{{ .Site.Params.favicon_ico_sizes  }}"{{ end }} />
   {{ end }}
   {{ if .Site.Params.favicon_png }}
-    <link rel="icon" href="/images/icons/{{ .Site.Params.favicon_png  }}" type="image/png" {{ if .Site.Params.favicon_png_sizes }}sizes="{{ .Site.Params.favicon_png_sizes  }}"{{ end }} />
+    <link rel="icon" href="{{ .Site.Params.favicon_png | printf "/images/icons/%s" | relURL  }}" type="image/png" {{ if .Site.Params.favicon_png_sizes }}sizes="{{ .Site.Params.favicon_png_sizes  }}"{{ end }} />
   {{ end }}
   {{ if .Site.Params.favicon_svg }}
-    <link rel="icon" href="/images/icons/{{ .Site.Params.favicon_svg  }}" type="image/svg+xml" sizes="any" />
+    <link rel="icon" href="{{ .Site.Params.favicon_svg | printf "/images/icons/%s" | relURL  }}" type="image/svg+xml" sizes="any" />
   {{ end }}
-  <link rel="apple-touch-icon-precomposed" href="/images/icons/{{ .Site.Params.appleicon  }}" />
+  <link rel="apple-touch-icon-precomposed" href="{{ .Site.Params.appleicon | printf "/images/icons/%s" | relURL  }}" />
 
-  <link rel="stylesheet" href="/assets/css/main.css" />
+	<link rel="stylesheet" href="{{ "/assets/css/main.css" | relURL }}" />
 
   {{ if not .Site.Params.custom_background }}
-    <link rel="stylesheet" href="/assets/css/page.css" />
+		<link rel="stylesheet" href="{{ "/assets/css/page.css" | relURL }}" />
   {{ end }}
 
   {{ if not .Site.Params.custom_icons }}
-    <link rel="stylesheet" href="/assets/css/font-awesome.min.css" />
+		<link rel="stylesheet" href="{{ "/assets/css/font-awesome.min.css" | relURL }}" />
   {{ end }}
 
   {{ range .Site.Params.custom_css }}
     <link rel="stylesheet" href="{{ . | absURL }}">
   {{ end }}
 
-  <!--[if lte IE 8]><script src="/assets/js/html5shiv.js"></script><![endif]-->
-  <!--[if lte IE 8]><link rel="stylesheet" href="/assets/css/ie8.css" /><![endif]-->
-  <!--[if lte IE 9]><link rel="stylesheet" href="/assets/css/ie9.css" /><![endif]-->
+	<!--[if lte IE 8]><script src="{{ "/assets/js/html5shiv.js" | relURL }}"></script><![endif]-->
+	<!--[if lte IE 8]><link rel="stylesheet" href="{{ "/assets/css/ie8.css" | relURL }}" /><![endif]-->
+	<!--[if lte IE 9]><link rel="stylesheet" href="{{ "/assets/css/ie9.css" | relURL }}" /><![endif]-->
 
-  <noscript><link rel="stylesheet" href="/assets/css/noscript.css" /></noscript>
+	<noscript><link rel="stylesheet" href="{{ "/assets/css/noscript.css" | relURL }}" /></noscript>
 </head>


### PR DESCRIPTION
Hi! First of all thanks for all your work, this is a great theme. 😄 

I was having a bit of trouble getting the theme to work on Gitlab pages due to the site not being hosted on a root directory but rather a sub-directory. This PR fixes this by transforming all of the asset and image URLs with the `relURL` hugo function that takes into account your `baseURL` setting in the configuration file.