### PR TITLE
Add social link configuration to specify target element

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -108,16 +108,19 @@ Even new lines and other markdown styles are working within the bio."""
     title = "Twitter"
     icon = "fa-twitter"
     link = "#"
+    target = "_blank"
 
   [[params.social]]
     title = "Instagram"
     icon = "fa-instagram"
     link = "#"
-    
+    target = "_blank"
+
   [[params.social]]
     title = "Facebook"
     icon = "fa-facebook"
     link = "#"
+    target = "_blank"
 
   # Footer settings
   [params.footer]

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -55,7 +55,7 @@
             <footer>
               <ul class="icons">
                 {{ range .Site.Params.social }}
-                  <li><a href="{{ .link }}" class="{{ .icon }}">{{ .title }}</a></li>
+                  <li><a href="{{ .link }}" class="{{ .icon }}" target="{{ .target | default "_self" }}">{{ .title }}</a></li>
                 {{ end }}
               </ul>
               {{ if .Site.Params.contact.enable }}


### PR DESCRIPTION
Add `target` config parameter to `[[params.social]]`.
We can specify href `target` element, and it will be able to open SNS link with new tab.